### PR TITLE
Switch to using IDs for referencing UAs.

### DIFF
--- a/misc/watch.sh
+++ b/misc/watch.sh
@@ -5,6 +5,7 @@ set -ex
 
 onchange \
   -i \
+  -v \
   '**/*' \
   --exclude-path .gitignore \
   --await-write-finish 2000 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -2789,6 +2789,12 @@
         }
       }
     },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
     "@types/webpack": {
       "version": "4.41.25",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.25.tgz",
@@ -5815,6 +5821,12 @@
         "xdg-basedir": "^2.0.0"
       },
       "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        },
         "xdg-basedir": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
@@ -22250,10 +22262,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^17.0.1",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^5.2.0",
+    "uuid": "^8.3.1",
     "webextension-polyfill-ts": "^0.22.0"
   },
   "devDependencies": {
@@ -24,6 +25,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-helmet": "^6.1.0",
     "@types/react-router-dom": "^5.1.6",
+    "@types/uuid": "^8.3.0",
     "manifoldjs": "^0.7.6",
     "onchange": "^7.1.0",
     "react-scripts": "^4.0.1",

--- a/src/background/context-menu-manager.ts
+++ b/src/background/context-menu-manager.ts
@@ -28,9 +28,7 @@ class ContextMenuManager {
         break;
       default:
         if (menuItemId.startsWith(UA_SPEC_PREFIX)) {
-          this.onSelectUaSpec(
-            parseInt(menuItemId.substr(UA_SPEC_PREFIX.length))
-          );
+          this.onSelectUaSpec(menuItemId.substr(UA_SPEC_PREFIX.length));
         }
         break;
     }
@@ -40,13 +38,13 @@ class ContextMenuManager {
     State.toggleEnabled();
   }
 
-  onSelectUaSpec(idx: number) {
-    State.setSelectedUaSpecIdx(idx);
+  onSelectUaSpec(id: string) {
+    State.setSelectedUaSpecId(id);
   }
 
   onStateChange() {
     browser.contextMenus.removeAll();
-    if (State.selectedUaSpec != null && State.uaSpecList.length > 0) {
+    if (State.selectedUaSpec !== null && State.uaSpecList.length > 0) {
       browser.contextMenus.create({
         contexts: ['browser_action'],
         id: TOGGLE_ENABLED,
@@ -60,12 +58,12 @@ class ContextMenuManager {
       id: UA_SPEC_LIST,
       title: 'Choose user agent',
     });
-    State.uaSpecList.forEach((uaSpec, idx) => {
+    State.uaSpecList.forEach((uaSpec) => {
       browser.contextMenus.create({
         contexts: ['browser_action'],
         type: 'radio',
-        checked: idx == State.selectedUaSpecIdx,
-        id: `${UA_SPEC_PREFIX}${idx}`,
+        checked: uaSpec.id === State.selectedUaSpecId,
+        id: `${UA_SPEC_PREFIX}${uaSpec.id}`,
         title: uaSpec.name,
         parentId: UA_SPEC_LIST,
       });

--- a/src/lib/ua-spec.ts
+++ b/src/lib/ua-spec.ts
@@ -1,6 +1,7 @@
 import DeviceType from './device-type';
 
 interface UaSpec {
+  id: string;
   deviceType: DeviceType;
   name: string;
   value: string;

--- a/src/options/edit-ua-list-card.tsx
+++ b/src/options/edit-ua-list-card.tsx
@@ -22,6 +22,7 @@ import CardTitle from 'src/lib/card-title';
 import DeviceTypeIcon from 'src/lib/device-type-icon';
 import UaSpec from 'src/lib/ua-spec';
 import State from 'src/state/state';
+import {v4 as uuidv4} from 'uuid';
 import './edit-ua-list-card.css';
 
 interface EditUaListCardState {
@@ -32,7 +33,7 @@ interface EditUaListCardState {
   editedUaSpec: UaSpec | null;
 }
 
-const NEW_UA_SPEC: UaSpec = {
+const NEW_UA_SPEC: Omit<UaSpec, 'id'> = {
   deviceType: 'desktop',
   name: '',
   value: '',
@@ -309,7 +310,7 @@ class EditUaListCard extends React.Component<{}, EditUaListCardState> {
     this.setState({
       activeUaSpecIdx: -1,
       isEditDialogOpen: true,
-      editedUaSpec: {...NEW_UA_SPEC},
+      editedUaSpec: {...NEW_UA_SPEC, id: uuidv4()},
     });
   }
 

--- a/src/popup/ua-list-card.tsx
+++ b/src/popup/ua-list-card.tsx
@@ -22,20 +22,20 @@ class UaListCard extends React.Component<{}, {}> {
       <Card>
         <CardTitle text="User agents" />
         <List>
-          {State.uaSpecList.map((uaSpec, idx) => (
+          {State.uaSpecList.map((uaSpec) => (
             <ListItem
-              key={idx}
+              key={uaSpec.id}
               button={true}
               dense={true}
-              onClick={() => State.setSelectedUaSpecIdx(idx)}
-              selected={idx == State.selectedUaSpecIdx}
+              onClick={() => State.setSelectedUaSpecId(uaSpec.id)}
+              selected={uaSpec.id === State.selectedUaSpecId}
             >
               <Radio
-                value={idx}
+                value={uaSpec.id}
                 color="default"
                 icon={<RadioButtonUnchecked />}
                 checkedIcon={<RadioButtonChecked />}
-                checked={idx == State.selectedUaSpecIdx}
+                checked={uaSpec.id === State.selectedUaSpecId}
               />
               <ListItemText primary={uaSpec.name} />
               <ListItemIcon>

--- a/src/state/default-ua-spec-list.ts
+++ b/src/state/default-ua-spec-list.ts
@@ -2,58 +2,67 @@ import UaSpec from 'src/lib/ua-spec';
 
 const DEFAULT_UA_SPEC_LIST: Array<UaSpec> = [
   {
+    id: '92ec566d-53ff-4ab6-a50a-a54ed12f981b',
     deviceType: 'desktop',
     name: 'Google Chrome',
     value:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36',
   },
   {
+    id: '15c291c1-3529-4120-bff5-d84b439ec812',
     deviceType: 'desktop',
     name: 'Safari (macOS)',
     value:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15',
   },
   {
+    id: 'eb4a6181-13b8-4f8d-ab52-01a2c33b9d07',
     deviceType: 'desktop',
     name: 'Microsoft Edge',
     value:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.67 Safari/537.36 Edg/87.0.664.52',
   },
   {
+    id: '8e4f486a-fe3c-47dd-8b96-99eee9d674c9',
     deviceType: 'desktop',
     name: 'Microsoft Internet Explorer 11',
     value:
       'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko',
   },
   {
+    id: 'c6003b93-235d-43a7-984c-b55b18d8636a',
     deviceType: 'desktop',
     name: 'Mozilla Firefox',
     value:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:63.0) Gecko/20100101 Firefox/63.0',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0',
   },
   {
+    id: '2c80aea5-80d1-448d-9227-476d58895b99',
     deviceType: 'mobile',
     name: 'Google Chrome (Android)',
     value:
-      'Mozilla/5.0 (Linux; Android 8.0.0; SM-G9600) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36',
+      'Mozilla/5.0 (Linux; Android 10; SM-N986U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Mobile Safari/537.36',
   },
   {
+    id: 'cfb8b051-7ecc-4664-9dd0-29f7684e0df8',
     deviceType: 'mobile',
     name: 'Safari (iPhone)',
     value:
       'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
   },
   {
+    id: 'f4e15410-f513-4aea-b733-2bd6b4cf5011',
     deviceType: 'mobile',
     name: 'Microsoft Edge (Windows Phone 10)',
     value:
       'Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 650) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15254',
   },
   {
+    id: '43e4c688-f8cb-4cf8-bcc8-af8a6da62c22',
     deviceType: 'tablet',
     name: 'Safari (iPad)',
     value:
-      ' Mozilla/5.0 (iPad; CPU OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+      'Mozilla/5.0 (iPad; CPU OS 13_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Mobile/15E148 Safari/604.1',
   },
 ];
 

--- a/src/state/default-ua-spec-list.ts
+++ b/src/state/default-ua-spec-list.ts
@@ -48,7 +48,7 @@ const DEFAULT_UA_SPEC_LIST: Array<UaSpec> = [
     deviceType: 'mobile',
     name: 'Safari (iPhone)',
     value:
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_9 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1',
   },
   {
     id: 'f4e15410-f513-4aea-b733-2bd6b4cf5011',


### PR DESCRIPTION
Previously, user agent configurations (`UaSpec` in the code) were referenced via their index in the list of configured user agents. This was the case both in the UI logic and in storage.

This is not a great design because a `UaSpec` can be moved around through the UI, so its index is not a stable reference. We only have one reference to the index right now (the currently selected UA) but we will have more when add support for rules. It would be very strange if we had to update all references to a UA when its position changes.

This PR changes the logic and the storage to use UUIDs to reference UAs, and provides a migration from the previous storage schema.